### PR TITLE
232 resolution data sync resolver

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -134,7 +134,7 @@ class SubstanceIndexResource(ResourceList):
     ---
     patch:
       tags:
-        - substance
+        - substance_index
       requestBody:
         content:
           application/vnd.api+json:
@@ -178,11 +178,28 @@ class SubstanceIndexResource(ResourceList):
                             properties:
                               identifier:
                                 type: object
+    delete:
+      tags:
+        - substance_index
+      responses:
+        200:
+          content:
+            application/vnd.api+json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      meta:
+                        type: object
+                        properties:
+                          message:
+                            type: string
+                            example: Database successfully cleared. __rows__ rows deleted
     """
 
     schema = SubstanceSchema
     data_layer = {"session": db.session, "model": Substance}
-    methods = ["POST"]
+    methods = ["POST", "DELETE"]
 
     def create_object(self, data, kwargs):
         """Creates or updates a model object
@@ -205,6 +222,24 @@ class SubstanceIndexResource(ResourceList):
         self._data_layer.session.merge(obj)
         self._data_layer.session.commit()
         return obj
+
+    def delete(self):
+        """Delete an object"""
+        rows_deleted = self.delete_db()
+
+        result = {
+            "meta": {
+                "message": f"Substance Index successfully cleared. {rows_deleted} rows deleted"
+            }
+        }
+
+        return result
+
+    def delete_db(self):
+        rows_deleted = self._data_layer.model.query.delete()
+        self._data_layer.session.commit()
+
+        return rows_deleted
 
 
 class SubstanceSearchResultList(ResourceList):

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -128,6 +128,73 @@ class SubstanceList(ResourceList):
     data_layer = {"session": db.session, "model": Substance}
 
 
+class SubstanceIndexResource(ResourceDetail):
+    """Create and Update an indexed substance
+
+    ---
+    patch:
+      tags:
+        - substance
+      parameters:
+        - in: path
+          name: sid
+          schema:
+            type: string
+            example: DTXSID1020000000
+      requestBody:
+        content:
+          application/vnd.api+json:
+            schema:
+              allOf:
+                - type: object
+                  properties:
+                    data:
+                      type: object
+                      properties:
+                        type:
+                          type: string
+                          example: substance
+                        id:
+                          type: string
+                          example: DTXSID1020000000
+                        attributes:
+                          type: object
+                          properties:
+                            identifier:
+                              type: object
+      responses:
+        200:
+          content:
+            application/vnd.api+json:
+              schema:
+                allOf:
+                  - type: object
+                    properties:
+                      data:
+                        type: object
+                        properties:
+                          type:
+                            type: string
+                            example: substance
+                          id:
+                            type: sid
+                            example: DTXSID1020000000
+                          attributes:
+                            type: object
+                            properties:
+                              identifier:
+                                type: object
+    """
+
+    schema = SubstanceSchema
+    data_layer = {"session": db.session, "model": Substance}
+    methods = ["PATCH"]
+
+    def update_object(self, data, qs, kwargs):
+        obj = self._data_layer.model(**data)
+        return self._data_layer.session.merge(obj)
+
+
 class SubstanceSearchResultList(ResourceList):
     """
 

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -128,19 +128,13 @@ class SubstanceList(ResourceList):
     data_layer = {"session": db.session, "model": Substance}
 
 
-class SubstanceIndexResource(ResourceDetail):
+class SubstanceIndexResource(ResourceList):
     """Create and Update an indexed substance
 
     ---
     patch:
       tags:
         - substance
-      parameters:
-        - in: path
-          name: sid
-          schema:
-            type: string
-            example: DTXSID1020000000
       requestBody:
         content:
           application/vnd.api+json:
@@ -163,7 +157,7 @@ class SubstanceIndexResource(ResourceDetail):
                             identifier:
                               type: object
       responses:
-        200:
+        201:
           content:
             application/vnd.api+json:
               schema:
@@ -188,11 +182,29 @@ class SubstanceIndexResource(ResourceDetail):
 
     schema = SubstanceSchema
     data_layer = {"session": db.session, "model": Substance}
-    methods = ["PATCH"]
+    methods = ["POST"]
 
-    def update_object(self, data, qs, kwargs):
+    def create_object(self, data, kwargs):
+        """Creates or updates a model object
+
+        Note:
+            This is a limited extension of
+            `flask_rest_jsonapi/data_layers/alchemy.py`
+            to allow for merges.
+            This will not handle relationships as there is no foreseeable need.
+
+        Args:
+            :param dict data: the data validated by marshmallow
+            :param dict kwargs: kwargs from the resource view
+
+        Returns:
+            :return DeclarativeMeta: an object from sqlalchemy
+        """
+
         obj = self._data_layer.model(**data)
-        return self._data_layer.session.merge(obj)
+        self._data_layer.session.merge(obj)
+        self._data_layer.session.commit()
+        return obj
 
 
 class SubstanceSearchResultList(ResourceList):

--- a/resolver/api/views.py
+++ b/resolver/api/views.py
@@ -16,7 +16,7 @@ from resolver.api.schemas import UserSchema, SubstanceSearchResultSchema
 
 api_versioning_v1 = "/api/v1"
 
-blueprint = Blueprint("api", __name__, url_prefix="/api/v1")
+blueprint = Blueprint("api", __name__, url_prefix=api_versioning_v1)
 restful_api = RestfulApi(blueprint)
 
 
@@ -32,8 +32,8 @@ def make_jsonapi(app):
     )
     jsonapi.route(
         SubstanceIndexResource,
-        "substance_indexing",
-        f"{api_versioning_v1}/substances/_index/<id>",
+        "substance_index",
+        f"{api_versioning_v1}/substances/_index",
     )
     jsonapi.route(
         SubstanceSearchResultList,

--- a/resolver/api/views.py
+++ b/resolver/api/views.py
@@ -2,6 +2,8 @@ from flask import Blueprint, current_app, jsonify
 from flask_rest_jsonapi import Api as JsonApi
 from flask_restful import Api as RestfulApi
 from marshmallow import ValidationError
+
+from resolver.api.resources.substance import SubstanceIndexResource
 from resolver.extensions import apispec
 from resolver.api.resources import (
     UserResource,
@@ -29,6 +31,11 @@ def make_jsonapi(app):
         SubstanceResource, "substance_detail", f"{api_versioning_v1}/substances/<id>"
     )
     jsonapi.route(
+        SubstanceIndexResource,
+        "substance_indexing",
+        f"{api_versioning_v1}/substances/_index/<id>",
+    )
+    jsonapi.route(
         SubstanceSearchResultList,
         "resolved_substance_list",
         f"{api_versioning_v1}/resolver",
@@ -40,6 +47,7 @@ def register_views():
     apispec.spec.components.schema("UserSchema", schema=UserSchema)
     apispec.spec.path(view=UserResource, app=current_app)
     apispec.spec.path(view=UserList, app=current_app)
+    apispec.spec.path(view=SubstanceIndexResource, app=current_app)
 
     apispec.spec.components.schema(
         "SubstanceSearchResultSchema", schema=SubstanceSearchResultSchema

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,12 +15,20 @@ class UserFactory(factory.Factory):
 class SubstanceFactory(factory.Factory):
 
     id = factory.Sequence(lambda n: f"DTXCID{n:09}")
-    identifiers = (
-        '{ "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",'
-        '"inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N", '
-        '"casalts":[{"casalt":"0001050799","weight:0.5},{"casalt":"1050799","weight":0.5}],'
-        '"synonyms": [{"synonym": "Meperon","weight": 0.75},{"synonym": "Methylperidol","weight": 0.5}]}'
-    )
+    identifiers = {
+        "preferred_name": "Moperone",
+        "display_name": "Moperone",
+        "casrn": "1050-79-9",
+        "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
+        "casalts": [
+            {"casalt": "0001050799", "weight": 0.5},
+            {"casalt": "1050799", "weight": 0.5},
+        ],
+        "synonyms": [
+            {"synonym": "Meperon", "weight": 0.75},
+            {"synonym": "Methylperidol", "weight": 0.5},
+        ],
+    }
 
     class Meta:
         model = Substance

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -1,4 +1,7 @@
+import pytest
 from flask import url_for
+
+from resolver.api.schemas import SubstanceSchema
 from resolver.models import Substance
 
 
@@ -245,3 +248,17 @@ def test_resolve_substance(client, db, substance):
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 2}
+
+
+# Tests both create and update functionality using param create_test.
+@pytest.mark.parametrize("create_test", [pytest.param(False), pytest.param(True)])
+def test_substance_index(client, db, substance_factory, create_test):
+    url = url_for("substance_index")
+    if create_test:
+        # instance to be created
+        instance = substance_factory.build()
+    else:
+        # instance to be updated
+        instance = substance_factory.create()
+    json = SubstanceSchema().dump(instance)
+    client.post(url, data=json, headers={"content-type": "application/vnd.api+json"})

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -254,11 +254,40 @@ def test_resolve_substance(client, db, substance):
 @pytest.mark.parametrize("create_test", [pytest.param(False), pytest.param(True)])
 def test_substance_index(client, db, substance_factory, create_test):
     url = url_for("substance_index")
+
     if create_test:
         # instance to be created
         instance = substance_factory.build()
     else:
         # instance to be updated
         instance = substance_factory.create()
-    json = SubstanceSchema().dump(instance)
-    client.post(url, data=json, headers={"content-type": "application/vnd.api+json"})
+        db.session.add(instance)
+        db.session.commit()
+    substance_dict = SubstanceSchema().dump(instance)
+    resp = client.post(
+        url, json=substance_dict, headers={"content-type": "application/vnd.api+json"}
+    )
+
+    assert resp.status_code == 201
+    results = resp.get_json()
+    assert results["data"]["attributes"]["identifiers"] == instance.identifiers
+
+
+def test_substance_index_delete(client, db, substance_factory):
+    url = url_for("substance_index")
+
+    # Create a Substance.  Add to test database
+    sub = substance_factory.create()
+    db.session.add(sub)
+    db.session.commit()
+    assert Substance.query.count() != 0
+
+    # Delete entire index
+    resp = client.delete(url, headers={"content-type": "application/vnd.api+json"})
+    results = resp.get_json()
+
+    # Verify response and database state
+    assert resp.status_code == 200
+    assert "Substance Index successfully cleared" in results["meta"]["message"]
+    assert Substance.query.count() == 0
+


### PR DESCRIPTION
Resolution half of ticket [chemcurator_django#232](https://github.com/Chemical-Curation/chemcurator_django/issues/232)

This adds a new endpoint for substances named POST `api/v1/substances/_index` that allows the creating/updating of a new substance resource.

Sample curl request:
```bash
curl --location --request POST 'http://localhost:5000/api/v1/substances/_index' \
--header 'Content-Type: application/vnd.api+json' \
--data-raw '{
    "data": {
        "type": "substance",
        "id": "DTXSID0050000000",
        "attributes": {
            "identifiers": {
                "preferred_name": "preferred name",
                "display_name": "Display Name",
                "casrn": "3000",
                "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N"
            }
        }
    }
}'
```

This also adds a new endpoint for substances named DELETE `api/v1/substances/_index` that allows the clearing of the whole substance table.

Sample curl request:
```bash
curl --location --request DELETE 'http://localhost:5000/api/v1/substances/_index' \
--header 'Content-Type: application/vnd.api+json'
```