### PR TITLE
248 synonym resolution

### DIFF
--- a/resolver/manage.py
+++ b/resolver/manage.py
@@ -50,7 +50,7 @@ def load_seed_data():
         id="DTXCID302000003",
         identifiers="{'preferred_name':'Moperone','casrn':'1050-79-9','inchikey': 'AGAHNABIDCTLHW-UHFFFAOYSA-N', "
         "'casalts':[{'casalt':'0001050799','weight':0.5},{'casalt':'1050799','weight':0.5}],"
-        "'synonyms': [{'synonym': 'Meperon','weight': 0.75},{'synonym': 'Methylperidol','weight': 0.5}]}",
+        "'synonyms': [{'identifier': 'Meperon','weight': 0.75},{'identifier': 'Methylperidol','weight': 0.5}]}",
     )
     db.session.add(s1)
     s2 = Substance(
@@ -58,8 +58,8 @@ def load_seed_data():
         identifiers="{'preferred_name':'Hydrogen peroxide','casrn':'7722-84-1',"
         "'inchikey': 'MHAJPDPJQMAIIY-UHFFFAOYSA-N', "
         "'casalts':[{'casalt':'0007722841','weight':0.5},{'casalt':'7722841','weight':0.5}],"
-        "'synonyms': [{'synonym': 'Hydrogen peroxide [USP]','weight': 0.75},"
-        "{'synonym': 'Wasserstoffperoxid','weight': 0.5}]}",
+        "'synonyms': [{'identifier': 'Hydrogen peroxide [USP]','weight': 0.75},"
+        "{'identifier': 'Wasserstoffperoxid','weight': 0.5}]}",
     )
 
     db.session.add(s2)

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -28,7 +28,6 @@ class Substance(db.Model):
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
 
-    val = db.column('value', type_=JSONB)
 
 ix_identifiers = db.Index(
     "ix_identifiers",

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -28,6 +28,7 @@ class Substance(db.Model):
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
 
+    val = db.column('value', type_=JSONB)
 
 ix_identifiers = db.Index(
     "ix_identifiers",

--- a/tests/Resolver.postman_collection.json
+++ b/tests/Resolver.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "ab9526aa-ab01-4a89-bc5d-3a3b285dcf85",
+		"_postman_id": "cb6a4105-3a38-4a92-8b5d-b686e714440a",
 		"name": "Resolver",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -28,7 +28,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{BaseURL}}/resolver?identifier=Moperone",
+					"raw": "{{BaseURL}}/resolver?identifier=ample",
 					"host": [
 						"{{BaseURL}}"
 					],
@@ -38,7 +38,7 @@
 					"query": [
 						{
 							"key": "identifier",
-							"value": "Moperone"
+							"value": "ample"
 						}
 					]
 				}
@@ -51,7 +51,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{BaseURL}}/resolver?identifier=Moperone",
+					"raw": "{{BaseURL}}/resolver?identifier=roxi",
 					"host": [
 						"{{BaseURL}}"
 					],
@@ -61,7 +61,7 @@
 					"query": [
 						{
 							"key": "identifier",
-							"value": "Moperone"
+							"value": "roxi"
 						}
 					]
 				}
@@ -271,7 +271,8 @@
 		{
 			"id": "b28b9cb9-42e0-42c3-8ba5-64af16467b37",
 			"key": "BaseURL",
-			"value": "http://localhost:5000/api/v1/"
+			"value": "http://localhost:5000/api/v1/",
+			"type": "string"
 		}
 	],
 	"protocolProfileBehavior": {}

--- a/tests/Resolver.postman_collection.json
+++ b/tests/Resolver.postman_collection.json
@@ -6,6 +6,36 @@
 	},
 	"item": [
 		{
+			"name": "issue_248",
+			"item": [
+				{
+					"name": "substance synonym identifier",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{BaseURL}}/resolver?identifier=Chem-5ical",
+							"host": [
+								"{{BaseURL}}"
+							],
+							"path": [
+								"resolver"
+							],
+							"query": [
+								{
+									"key": "identifier",
+									"value": "Chem-5ical"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"description": "I want to be able to able to find a substance using a name or casrn that exists in the synonyms rather than the substance model",
+			"protocolProfileBehavior": {}
+		},
+		{
 			"name": "GET Substances",
 			"request": {
 				"method": "GET",

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -16,10 +16,10 @@ class SubstanceFactory(factory.Factory):
 
     id = factory.Sequence(lambda n: f"DTXCID{n:09}")
     identifiers = (
-        '{ "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",'
-        '"inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N", '
-        '"casalts":[{"casalt":"0001050799","weight:0.5},{"casalt":"1050799","weight":0.5}],'
-        '"synonyms": [{"identifier": "Meperon","weight": 0.75},{"identifier": "Methylperidol","weight": 0.5}]}'
+        { "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",
+        "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
+        "casalts":[{"casalt":"0001050799","weight":0.5},{"casalt":"1050799","weight":0.5}],
+        "synonyms": [{"identifier": "Meperon","weight": 0.75},{"identifier": "Methylperidol","weight": 0.5}]}
     )
 
     class Meta:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -19,7 +19,7 @@ class SubstanceFactory(factory.Factory):
         '{ "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",'
         '"inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N", '
         '"casalts":[{"casalt":"0001050799","weight:0.5},{"casalt":"1050799","weight":0.5}],'
-        '"synonyms": [{"synonym": "Meperon","weight": 0.75},{"synonym": "Methylperidol","weight": 0.5}]}'
+        '"synonyms": [{"identifier": "Meperon","weight": 0.75},{"identifier": "Methylperidol","weight": 0.5}]}'
     )
 
     class Meta:

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -184,7 +184,10 @@ def test_resolve_substance(client, db, substance):
                 "identifier": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
                 "weight": 0.75,
             },
-            {"identifier": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide", "weight": 0.5},
+            {
+                "identifier": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide",
+                "weight": 0.5,
+            },
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -47,8 +47,8 @@ def test_patch_substance(client, db, substance):
             {"casalt": "1050799", "weight": 0.5},
         ],
         "synonyms": [
-            {"synonym": "Meperon", "weight": 0.75},
-            {"synonym": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75},
+            {"identifier": "Methylperidol", "weight": 0.5},
         ],
     }
     data["data"]["id"] = substance.id
@@ -103,8 +103,8 @@ def test_create_substance(client, db):
             {"casalt": "1050799", "weight": 0.5},
         ],
         "synonyms": [
-            {"synonym": "Meperon", "weight": 0.75},
-            {"synonym": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75},
+            {"identifier": "Methylperidol", "weight": 0.5},
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -157,8 +157,8 @@ def test_resolve_substance(client, db, substance):
             {"casalt": "1050799", "weight": 0.5},
         ],
         "synonyms": [
-            {"synonym": "Meperon", "weight": 0.75},
-            {"synonym": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75},
+            {"identifier": "Methylperidol", "weight": 0.5},
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -181,10 +181,10 @@ def test_resolve_substance(client, db, substance):
         ],
         "synonyms": [
             {
-                "synonym": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
+                "identifier": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
                 "weight": 0.75,
             },
-            {"synonym": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide", "weight": 0.5},
+            {"identifier": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide", "weight": 0.5},
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -221,6 +221,16 @@ def test_resolve_substance(client, db, substance):
     search_url = url_for("resolved_substance_list", identifier=display_name)
     rep = client.get(search_url)
     assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
+    # test display name match
+    synonym = "Meperon"
+    search_url = url_for("resolved_substance_list", identifier=synonym)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
 
     # test name containment
     partial_name = "Miracle"


### PR DESCRIPTION
closes [chemcurator_django#248](https://github.com/Chemical-Curation/chemcurator_django/issues/248)

This was pretty easy in concept.  Battling SqlAlchemy ORM made it much harder.

Additional Changes:
- Removed the 404 if a query returns no results.  Instead an empty data object will be returned instead.  Searches that return nothing shouldn't be considered erroneous.
- Changed seed data synonyms to be an array containing objects modeled as such `{identifier: "foo", weight: 0.5}`