### PR TITLE
171 substance compound id resolver

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -277,6 +277,8 @@ class SubstanceSearchResultList(ResourceList):
                         Substance.identifiers["preferred_name"].astext.contains(
                             search_term
                         ),
+                        Substance.identifiers["compound_id"].astext.ilike(search_term),
+                        Substance.id.ilike(search_term),
                         Substance.identifiers["casrn"].astext.contains(search_term),
                         Substance.identifiers["display_name"].astext.contains(
                             search_term
@@ -297,6 +299,8 @@ class SubstanceSearchResultList(ResourceList):
                         Substance.identifiers["preferred_name"].astext.ilike(
                             f"%{search_term}%"
                         ),
+                        Substance.identifiers["compound_id"].astext.ilike(search_term),
+                        Substance.id.ilike(search_term),
                         Substance.identifiers["casrn"].astext.ilike(f"%{search_term}%"),
                         Substance.identifiers["display_name"].astext.ilike(
                             f"%{search_term}%"

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -234,6 +234,14 @@ def test_resolve_substance(client, db, substance):
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
 
+    # test SID match
+    sid = "DTXSID60191004"
+    search_url = url_for("resolved_substance_list", identifier=sid)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
     # test name containment
     partial_name = "Miracle"
     search_url = url_for("resolved_substance_list", identifier=partial_name)

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -179,6 +179,7 @@ def test_resolve_substance(client, db, substance):
         "display_name": "Butyric acid Original Dressing",
         "casrn": "3757-31-1",
         "inchikey": "UUTBLVFYDQGDNV-UHFFFAOYSA-N",
+        "compound_id": "DTXCID302000003",
         "casalts": [
             {"casalt": "3757-31-1", "weight": 0.5},
         ],
@@ -224,6 +225,14 @@ def test_resolve_substance(client, db, substance):
     search_url = url_for("resolved_substance_list", identifier=display_name)
     rep = client.get(search_url)
     assert rep.status_code == 200
+
+    # test CID match
+    cid = "DTXCID302000003"
+    search_url = url_for("resolved_substance_list", identifier=cid)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
 
     # test name containment
     partial_name = "Miracle"


### PR DESCRIPTION
helps close [chemcurator_django#171](https://github.com/Chemical-Curation/chemcurator_django/issues/171)

Check for both sid and cid using ilike.  Does not use contains as this would be meaningless.