### PR TITLE
144 match and score

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -303,7 +303,12 @@ class SubstanceSearchResultList(ResourceList):
                 .populate_existing()
                 .options(
                     with_expression(
-                        Substance.search_score, Substance.id.ilike(search_term)
+                        # first argument is the name of an empty query_expression() defined on the model
+                        Substance.orm_score,
+                        # the actual expression for scoring the resolved results
+                        Substance.identifiers["display_name"].astext.ilike(
+                            f"%{search_term}%"
+                        ),
                     )
                 )
             )

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -284,47 +284,21 @@ class SubstanceSearchResultList(ResourceList):
                 .subquery()
             )
 
-            query_ = (
-                self.session.query(Substance)
-                .filter(
-                    or_(
-                        Substance.identifiers["preferred_name"].astext.ilike(
-                            f"%{search_term}%"
-                        ),
-                        Substance.identifiers["compound_id"].astext.ilike(search_term),
-                        Substance.id.ilike(search_term),
-                        Substance.identifiers["casrn"].astext.ilike(f"%{search_term}%"),
-                        Substance.identifiers["display_name"].astext.ilike(
-                            f"%{search_term}%"
-                        ),
-                        Substance.id.in_(synonym_subquery),
-                    )
-                )
-                .populate_existing()
-                .options(
-                    with_expression(
-                        # first argument is the name of an empty query_expression() defined on the model
-                        Substance.orm_score,
-                        # the actual expression for scoring the resolved results
-                        Substance.identifiers["display_name"].astext.ilike(
-                            f"%{search_term}%"
-                        ),
-                    )
+            query_ = self.session.query(Substance).filter(
+                or_(
+                    Substance.identifiers["preferred_name"].astext.ilike(
+                        f"%{search_term}%"
+                    ),
+                    Substance.identifiers["compound_id"].astext.ilike(search_term),
+                    Substance.id.ilike(search_term),
+                    Substance.identifiers["casrn"].astext.ilike(f"%{search_term}%"),
+                    Substance.identifiers["display_name"].astext.ilike(
+                        f"%{search_term}%"
+                    ),
+                    Substance.id.in_(synonym_subquery),
                 )
             )
         return query_
-
-    def after_get_collection(self, collection, qs, view_kwargs):
-        """
-        TODO: Scoring the members of the collection could happen here
-        See https://github.com/Chemical-Curation/chemcurator_django/issues/144
-        Each member of the collection is a `sqlalchemy.orm.state.InstanceState` object
-        """
-        print("--- after_get_collection ---")
-        print(request.args)
-        for item in collection:
-            print(item.__dict__)
-        return collection
 
     methods = ["GET"]
     schema = SubstanceSearchResultSchema
@@ -334,6 +308,5 @@ class SubstanceSearchResultList(ResourceList):
         "model": Substance,
         "methods": {
             "query": query,
-            "after_get_collection": after_get_collection,
         },
     }

--- a/resolver/api/schemas/substance.py
+++ b/resolver/api/schemas/substance.py
@@ -28,11 +28,10 @@ class SubstanceSearchResultSchema(Schema):
     orm_score = fields.Raw(dump_only=True)
 
     def score_matches(self, substance, **view_kwargs):
-
+        matches = {}  # a dictionary of matched fields and scores
         if request.args.get("identifier") is not None:
             search_term = request.args.get("identifier")
             id_dict = substance.identifiers
-            matches = {}  # a dictionary of matched fields and scores
             # start comparing identifiers
             if id_dict["preferred_name"]:
                 if re.search(search_term, id_dict["preferred_name"]):
@@ -43,6 +42,11 @@ class SubstanceSearchResultSchema(Schema):
             if id_dict["casrn"]:
                 if re.search(search_term, id_dict["casrn"]):
                     matches["casrn"] = 1
+            if id_dict["synonyms"]:
+                matches["synonyms"] = {}
+                for synonym in id_dict["synonyms"]:
+                    if re.search(search_term, synonym["identifier"]):
+                        matches["synonyms"][synonym["identifier"]] = synonym["weight"]
 
         return matches
 

--- a/resolver/api/schemas/substance.py
+++ b/resolver/api/schemas/substance.py
@@ -50,9 +50,7 @@ class SubstanceSearchResultSchema(Schema):
             if id_dict["synonyms"]:
                 for synonym in id_dict["synonyms"]:
                     if re.search(search_term, synonym["identifier"]):
-                        matches[f'Matched synonym {synonym["identifier"]}'] = synonym[
-                            "weight"
-                        ]
+                        matches[f'Matched {synonym["synonymtype"]}'] = synonym["weight"]
 
             if bool(matches):
                 max_key = max(matches, key=matches.get)

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -28,7 +28,7 @@ class Substance(db.Model):
 
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
-    search_score = query_expression()
+    orm_score = query_expression()
 
 
 ix_identifiers = db.Index(

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -3,7 +3,8 @@ from resolver.extensions import db
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.indexable import index_property
 from sqlalchemy import text
-from sqlalchemy.sql import func
+from sqlalchemy.sql import func, literal
+from sqlalchemy.orm import query_expression
 
 
 class Substance(db.Model):
@@ -27,6 +28,7 @@ class Substance(db.Model):
 
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
+    search_score = query_expression()
 
 
 ix_identifiers = db.Index(

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -3,8 +3,7 @@ from resolver.extensions import db
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.indexable import index_property
 from sqlalchemy import text
-from sqlalchemy.sql import func, literal
-from sqlalchemy.orm import query_expression
+from sqlalchemy.sql import func
 
 
 class Substance(db.Model):
@@ -28,7 +27,6 @@ class Substance(db.Model):
 
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
-    orm_score = query_expression()
 
 
 ix_identifiers = db.Index(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,12 +15,20 @@ class UserFactory(factory.Factory):
 class SubstanceFactory(factory.Factory):
 
     id = factory.Sequence(lambda n: f"DTXCID{n:09}")
-    identifiers = (
-        { "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",
+    identifiers = {
+        "preferred_name": "Moperone",
+        "display_name": "Moperone",
+        "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts":[{"casalt":"0001050799","weight":0.5},{"casalt":"1050799","weight":0.5}],
-        "synonyms": [{"identifier": "Meperon","weight": 0.75},{"identifier": "Methylperidol","weight": 0.5}]}
-    )
+        "casalts": [
+            {"casalt": "0001050799", "weight": 0.5},
+            {"casalt": "1050799", "weight": 0.5},
+        ],
+        "synonyms": [
+            {"identifier": "Meperon", "weight": 0.75},
+            {"identifier": "Methylperidol", "weight": 0.5},
+        ],
+    }
 
     class Meta:
         model = Substance

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -45,13 +45,19 @@ def test_patch_substance(client, db, substance):
         "preferred_name": "Moperone Updated",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "0001050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {"identifier": "1050799", "weight": 0.5, "synonymtype": "Alternate CAS-RN"},
         ],
     }
     data["data"]["id"] = substance.id
@@ -100,13 +106,15 @@ def test_create_substance(client, db):
         "display_name": "Miracle Whip",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
+            {"identifier": "0001050799", "weight": 0.5, "synonymtype": "Generic Name"},
+            {"identifier": "1050799", "weight": 0.5, "synonymtype": "Generic Name"},
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -154,14 +162,28 @@ def test_resolve_substance(client, db, substance):
         "display_name": "Kraft Miracle Whip Original Dressing",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
-            {"identifier": "Ambiguous synonym", "weight": 0.2},
+            {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "Ambiguous synonym",
+                "weight": 0.2,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "0001050799",
+                "weight": 0.8,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": "1050799",
+                "weight": 0.8,
+                "synonymtype": "Alternate CAS-RN",
+            },
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -180,19 +202,23 @@ def test_resolve_substance(client, db, substance):
         "casrn": "3757-31-1",
         "inchikey": "UUTBLVFYDQGDNV-UHFFFAOYSA-N",
         "compound_id": "DTXCID302000003",
-        "casalts": [
-            {"casalt": "3757-31-1", "weight": 0.5},
-        ],
         "synonyms": [
             {
                 "identifier": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
                 "weight": 0.75,
+                "synonymtype": "Generic Name",
             },
             {
                 "identifier": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide",
                 "weight": 0.5,
+                "synonymtype": "Generic Name",
             },
             {"identifier": "Miracle Whip", "weight": 0.2},
+            {
+                "identifier": "3757-31-1",
+                "weight": 0.2,
+                "synonymtype": "Alternate CAS_RN",
+            },
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -245,8 +271,7 @@ def test_resolve_substance(client, db, substance):
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
     assert (
-        results["data"][0]["attributes"]["searchscore"]["Matched synonym Meperon"]
-        == 0.75
+        results["data"][0]["attributes"]["searchscore"]["Matched Generic Name"] == 0.75
     )
 
     # test preferred_name versus synonym match

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -63,7 +63,6 @@ def test_patch_substance(client, db, substance):
         substance_url, json=data, headers={"content-type": "application/vnd.api+json"}
     )
     assert rep.status_code == 200
-    print(rep.get_json())
     substance_idents = rep.get_json()["data"]["attributes"]["identifiers"]
     assert substance_idents == new_idents
 
@@ -214,6 +213,8 @@ def test_resolve_substance(client, db, substance):
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["matches"]["preferred_name"] == 1
+    assert results["data"][0]["attributes"]["matches"]["display_name"] == 1
 
     # test CASRN match
     casrn = "1050-79-9"
@@ -222,6 +223,7 @@ def test_resolve_substance(client, db, substance):
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["matches"]["casrn"] == 1
 
     # test display name match
     display_name = "Kraft Miracle Whip Original Dressing"
@@ -230,14 +232,16 @@ def test_resolve_substance(client, db, substance):
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["matches"]["display_name"] == 1
 
-    # test display name match
+    # test synonym match
     synonym = "Meperon"
     search_url = url_for("resolved_substance_list", identifier=synonym)
     rep = client.get(search_url)
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["matches"]["synonyms"] == {"Meperon": 0.75}
 
     # test CID match
     cid = "DTXCID302000003"
@@ -320,4 +324,3 @@ def test_substance_index_delete(client, db, substance_factory):
     assert resp.status_code == 200
     assert "Substance Index successfully cleared" in results["meta"]["message"]
     assert Substance.query.count() == 0
-


### PR DESCRIPTION
closes: https://github.com/Chemical-Curation/chemcurator_django/issues/144

Must be reviewed and merged with https://github.com/Chemical-Curation/chemcurator_django/pull/282

Once the query returns all the results, the serializer adds a new `searchscore` attribute that reports the highest-scoring match. 

Before testing, use `python manage.py sync` to reload the indexed substances. Then here are some searches to test with:

A string that matches both partial and full display names:
http://127.0.0.1:5000/api/v1/resolver?identifier=Sample%20Substance
Also:
http://127.0.0.1:5000/api/v1/resolver?identifier=peroxide

In this case, the match of "Sample Substance" to a `display_name` of "Display Sample Substance 2" is being returned by the  not being scored because we have not yet added the functionality for scoring partial matches.

The same thing happens with a DTXSID search:
http://127.0.0.1:5000/api/v1/resolver?identifier=DTXSID602000001

A full match on a display name gets scored with 1:
http://127.0.0.1:5000/api/v1/resolver?identifier=Hydrogen%20Peroxide

Synonyms:
http://127.0.0.1:5000/api/v1/resolver?identifier=this%20is%20a%20synonym
http://127.0.0.1:5000/api/v1/resolver?identifier=Chem-5ical

A CASRN:
http://127.0.0.1:5000/api/v1/resolver?identifier=6229215-51-8

A synonym of that same record:
http://127.0.0.1:5000/api/v1/resolver?identifier=Sorbic%20Acid

See my questions on the ticket: https://github.com/Chemical-Curation/chemcurator_django/issues/144#issuecomment-732640549

How does the `SubstanceSearchResultSchema` (a `marshmallow_jsonapi.schema` object) know how to sort? It does not always appear to use the primary key.