### PR TITLE
144 score results

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-# WARNING: this file is not suitable for production, please use with caution
+  # WARNING: this file is not suitable for production, please use with caution
 version: "3"
 
 services:

--- a/resolver/api/data_layers.py
+++ b/resolver/api/data_layers.py
@@ -1,0 +1,78 @@
+from flask import current_app, request
+from flask_rest_jsonapi.data_layers.alchemy import SqlalchemyDataLayer
+
+
+class SearchDataLayer(SqlalchemyDataLayer):
+    """Sqlalchemy data layer specifically to use python sorting."""
+
+    def get_collection(self, qs, view_kwargs, filters=None):
+        """Retrieve a collection of objects through sqlalchemy
+
+        :param QueryStringManager qs: a querystring manager to retrieve information from url
+        :param dict view_kwargs: kwargs from the resource view
+        :param dict filters: A dictionary of key/value filters to apply to the eventual query
+        :return tuple: the number of object and the list of objects
+        """
+        self.before_get_collection(qs, view_kwargs)
+
+        query = self.query(view_kwargs)
+
+        if filters:
+            query = query.filter_by(**filters)
+
+        if qs.filters:
+            query = self.filter_query(query, qs.filters, self.model)
+
+        object_count = query.count()
+
+        # todo: limit generic searches?
+        # if object_count > current_app.config['MAX_SEARCHED_ENTRIES']:
+        #     raise Exception
+
+        if getattr(self, "eagerload_includes", True):
+            query = self.eagerload_includes(query, qs)
+
+        collection = query.all()
+
+        collection = self.calculate_scores(collection, qs, view_kwargs)
+
+        collection = self.paginate_collection(collection, qs.pagination)
+
+        collection = self.after_get_collection(collection, qs, view_kwargs)
+
+        return object_count, collection
+
+    def paginate_collection(self, collection, paginate_info):
+        """Paginate query according to jsonapi 1.0
+
+        :param Query collection: sqlalchemy collection
+        :param dict paginate_info: pagination information
+        :return Query: the paginated query
+        """
+        if int(paginate_info.get("size", 1)) == 0:
+            return collection
+
+        page_size = int(paginate_info.get("size", 0)) or current_app.config["PAGE_SIZE"]
+
+        start = 0
+        if paginate_info.get("number"):
+            start = (int(paginate_info["number"]) - 1) * page_size
+
+        end = start + page_size
+
+        collection = collection[start:end]
+
+        return collection
+
+    def calculate_scores(self, collection, qs, view_kwargs):
+        """
+        Sorts the returned records by the value returned by Substance.score_result
+        It is not possible to apply the score_result hybrid method at the class level,
+        so we cannot just append `.order_by(Substance.score_result(search_term).desc())`
+        to the query. The score_result method only works at the row/instance level
+        """
+        if request.args.get("identifier") is not None:
+            search_term = request.args.get("identifier")
+            collection.sort(key=lambda x: x.score_result(search_term), reverse=True)
+
+        return collection

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -307,20 +307,15 @@ class SubstanceSearchResultList(ResourceList):
         return query_
 
     def after_get_collection(self, collection, qs, view_kwargs):
-        """"""
+        """
+        Sorts the returned records by the value returned by Substance.score_result
+        It is not possible to apply the score_result hybrid method at the class level,
+        so we cannot just append `.order_by(Substance.score_result(search_term).desc())`
+        to the query. The score_result method only works at the row/instance level
+        """
         if request.args.get("identifier") is not None:
             search_term = request.args.get("identifier")
             collection.sort(key=lambda x: x.score_result(search_term), reverse=True)
-
-        print("after_get_collection")
-        print(qs.__dict__)
-        for r in collection:
-            print(r)
-        # sort the returned records by the value returned by Substance.score_result
-        # It is not possible to apply the score_Result hybrid method at the class level,
-        # so we cannot just append
-        #    .order_by(Substance.score_result(search_term).desc())
-        # to the query. The score_result method only works at the row/instance level
 
         return collection
 

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -284,13 +284,7 @@ class SubstanceSearchResultList(ResourceList):
                 .subquery()
             )
 
-            query_ = self.session.query(
-                Substance,
-                # try stashing the search term in the query at the row level for the benefit
-                # of the Schema deserializer
-                # literal_column(f"'{search_term}'")
-                # .label("search_term")
-            ).filter(
+            query_ = self.session.query(Substance,).filter(
                 or_(
                     Substance.identifiers["preferred_name"].astext.ilike(
                         f"%{search_term}%"

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -306,7 +306,12 @@ class SubstanceSearchResultList(ResourceList):
         This method could also populate the `matches` field in the serialized
         SubstanceSearchResultSchema
         """
-        pass
+        print("after_get_collection")
+        if request.args.get("identifier") is not None:
+            search_term = request.args.get("identifier")
+        # sort the returned records by the value returned by Substance.score_result
+        collection.sort(key=lambda x: x.score_result(search_term), reverse=True)
+        return collection
 
     methods = ["GET"]
     schema = SubstanceSearchResultSchema
@@ -316,6 +321,6 @@ class SubstanceSearchResultList(ResourceList):
         "model": Substance,
         "methods": {
             "query": query,
-            # "after_get_collection": after_get_collection,
+            "after_get_collection": after_get_collection,
         },
     }

--- a/resolver/api/schemas/substance.py
+++ b/resolver/api/schemas/substance.py
@@ -2,6 +2,7 @@ from resolver.models import Substance
 from resolver.extensions import db
 from marshmallow_jsonapi.schema import Schema
 from marshmallow_jsonapi import fields
+from flask import request
 
 
 class SubstanceSchema(Schema):
@@ -14,6 +15,7 @@ class SubstanceSchema(Schema):
         self_view = "substance_detail"
         self_view_kwargs = {"id": "<id>"}
         self_view_many = "substance_list"
+        self_url_kwargs = {"identifier": "<identifier>"}
 
 
 class SubstanceSearchResultSchema(Schema):
@@ -24,14 +26,11 @@ class SubstanceSearchResultSchema(Schema):
     matches = fields.Function(
         lambda obj: "[{}, {}]".format("matching field 1", "matching field 2")
     )
-    # the score will be calculated in the resolver
-    # https://github.com/Chemical-Curation/chemcurator_django/issues/144
-    score = fields.Function(lambda obj: 1)
+    score = fields.Function(lambda obj: obj.score_result("foo"))
 
     class Meta:
         type_ = "substance_search_results"
         self_view_many = "resolved_substance_list"
-        self_view_kwargs = {"identifier": "<identifier>"}
         model = Substance
         sqla_session = db.session
         load_instance = True

--- a/resolver/api/schemas/substance.py
+++ b/resolver/api/schemas/substance.py
@@ -15,7 +15,6 @@ class SubstanceSchema(Schema):
         self_view = "substance_detail"
         self_view_kwargs = {"id": "<id>"}
         self_view_many = "substance_list"
-        self_url_kwargs = {"identifier": "<identifier>"}
 
 
 class SubstanceSearchResultSchema(Schema):
@@ -24,9 +23,11 @@ class SubstanceSearchResultSchema(Schema):
     identifiers = fields.Raw(required=True)
     # the matches will be the fields in which the identifier was found
     matches = fields.Function(
-        lambda obj: "[{}, {}]".format("matching field 1", "matching field 2")
+        lambda obj: obj.get_matches(request.args.get("identifier"))
     )
-    score = fields.Function(lambda obj: obj.score_result("foo"))
+    score = fields.Function(
+        lambda obj: obj.score_result(request.args.get("identifier"))
+    )
 
     class Meta:
         type_ = "substance_search_results"

--- a/resolver/app.py
+++ b/resolver/app.py
@@ -2,7 +2,7 @@ from flask import Flask
 
 from resolver import auth
 from resolver.api import views as api_views
-from resolver.extensions import db, jwt, migrate, apispec, init_db
+from resolver.extensions import db, jwt, migrate, apispec, init_db, ma
 
 
 def create_app(testing=False, cli=False):
@@ -28,6 +28,7 @@ def configure_extensions(app, cli):
     """configure flask extensions"""
     db.init_app(app)
     jwt.init_app(app)
+    ma.init_app(app)
 
     if cli is True:
         migrate.init_app(app, db)

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -37,8 +37,9 @@ class Substance(db.Model):
             for id_name in ["casrn", "preferred_name", "display_name", "compound_id"]:
                 # an exact match against a top-level identifier
                 # yields a 1.0 score
-                if self.identifiers[id_name] == searchterm:
-                    matchlist[id_name] = 1
+                if self.identifiers[id_name]:
+                    if self.identifiers[id_name] == searchterm:
+                        matchlist[id_name] = 1
             if self.identifiers["synonyms"]:
                 synonyms = self.identifiers["synonyms"]
                 # a match against a synonym identifier
@@ -57,6 +58,11 @@ class Substance(db.Model):
 
     @hybrid_method
     def score_result(self, searchterm=None):
+        """
+        Technical debt here: the identifiers in the indexed document are hard-coded
+        into the scoring loop
+        https://github.com/Chemical-Curation/resolver/pull/16#discussion_r536216962
+        """
         matches = self.get_matches(searchterm)
         max_score = 0
         if matches:

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.indexable import index_property
 from sqlalchemy import text
 from sqlalchemy.sql import func
+from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
 
 
 class Substance(db.Model):
@@ -27,6 +28,15 @@ class Substance(db.Model):
 
     casrn = index_property("identifiers", "casrn", default=None)
     preferred_name = index_property("identifiers", "preferred_name", default=None)
+
+    @hybrid_method
+    def score_result(self, searchterm=None):
+        if bool(searchterm):
+            # search the identifiers for the term and score them
+            print(f"Scoring {searchterm} against {self.identifiers}")
+            return 0.99
+        else:
+            return None
 
 
 ix_identifiers = db.Index(

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -4,7 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.indexable import index_property
 from sqlalchemy import text
 from sqlalchemy.sql import func
-from sqlalchemy.ext.hybrid import hybrid_method, hybrid_property
+from sqlalchemy.ext.hybrid import hybrid_method
 
 
 class Substance(db.Model):

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -33,8 +33,25 @@ class Substance(db.Model):
     def score_result(self, searchterm=None):
         if bool(searchterm):
             # search the identifiers for the term and score them
-            print(f"Scoring {searchterm} against {self.identifiers}")
-            return 0.99
+            # print(f"Scoring {searchterm} against {self.identifiers}")
+            print(f"Scoring {searchterm} ")
+            matchlist = {}
+            for id_name in self.identifiers.keys():
+                if self.identifiers[id_name] == searchterm:
+                    matchlist[id_name] = 1
+            if self.identifiers["synonyms"]:
+                synonyms = self.identifiers["synonyms"]
+                for synonym in synonyms:
+                    synid = synonym["identifier"] if synonym["identifier"] else ""
+                    if synid == searchterm:
+                        matchlist[synonym["synonymtype"]] = synonym["weight"]
+
+            print(matchlist)
+            if matchlist:
+                score = 1.0
+            else:
+                score = 0
+            return score
         else:
             return None
 

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -34,7 +34,7 @@ class Substance(db.Model):
         if bool(searchterm):
             # search the identifiers for the term and score them
             matchlist = {}
-            for id_name in ["casrn", "preferred_name", "display_name","compound_id"]:
+            for id_name in ["casrn", "preferred_name", "display_name", "compound_id"]:
                 # an exact match against a top-level identifier
                 # yields a 1.0 score
                 if self.identifiers[id_name] == searchterm:

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -23,12 +23,6 @@ class SubstanceProvider(BaseProvider):
     Fake color names are as good as any other dummy string for substances
     """
 
-    def substancename(self):
-        return fake.color_name()
-
-    def synonymidentifier(self):
-        return fake.color_name()
-
     def synonymtype(self):
         return fake.random_elements(
             elements=("Generic Name", "Alternate CAS-RN", "Collapsed CAS-RN", "EINECS"),
@@ -40,7 +34,7 @@ class SubstanceProvider(BaseProvider):
 
     def substanceidentifierjson(self):
         identifiers = {}
-        identifiers["preferred_name"] = fake.color_name()
+        identifiers["preferred_name"] = fake.sentence(nb_words=3)
         identifiers["display_name"] = identifiers["preferred_name"]
         identifiers["casrn"] = fake.numerify(text="####-##-#")
         identifiers["inchikey"] = fake.lexify(text="????????????-??????????-?")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,5 +1,11 @@
 import factory
+from faker import Faker
+from faker.providers import BaseProvider
+
 from resolver.models import User, Substance
+
+fake = Faker()
+Faker.seed(0)
 
 
 class UserFactory(factory.Factory):
@@ -12,15 +18,60 @@ class UserFactory(factory.Factory):
         model = User
 
 
-class SubstanceFactory(factory.Factory):
+class SubstanceProvider(BaseProvider):
+    """
+    Fake color names are as good as any other dummy string for substances
+    """
 
-    id = factory.Sequence(lambda n: f"DTXCID{n:09}")
-    identifiers = (
-        { "preferred_name":"Moperone","display_name":"Moperone","casrn":"1050-79-9",
-        "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts":[{"casalt":"0001050799","weight":0.5},{"casalt":"1050799","weight":0.5}],
-        "synonyms": [{"identifier": "Meperon","weight": 0.75},{"identifier": "Methylperidol","weight": 0.5}]}
-    )
+    def substancename(self):
+        return fake.color_name()
+
+    def synonymidentifier(self):
+        return fake.color_name()
+
+    def synonymtype(self):
+        return fake.random_elements(
+            elements=("Generic Name", "Alternate CAS-RN", "Collapsed CAS-RN", "EINECS"),
+            length=1,
+        )[0]
+
+    def synonymweight(self):
+        return fake.randomize_nb_elements(number=40) / 100
+
+    def substanceidentifierjson(self):
+        identifiers = {}
+        identifiers["preferred_name"] = fake.color_name()
+        identifiers["display_name"] = identifiers["preferred_name"]
+        identifiers["casrn"] = fake.numerify(text="####-##-#")
+        identifiers["inchikey"] = fake.lexify(text="????????????-??????????-?")
+        identifiers["compound_id"] = fake.numerify(text="DTXCID#########")
+        identifiers["synonyms"] = [
+            {
+                "identifier": fake.numerify(text="00######"),
+                "weight": fake.randomize_nb_elements(number=50) / 100,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": fake.numerify(text="00######"),
+                "weight": fake.randomize_nb_elements(number=50) / 100,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": fake.color_name(),
+                "weight": fake.randomize_nb_elements(number=50) / 100,
+                "synonymtype": "Generic Name",
+            },
+        ]
+        return identifiers
+
+
+fake.add_provider(SubstanceProvider)
+
+
+class SubstanceFactory(factory.Factory):
+    id = factory.Sequence(lambda n: f"DTXSID{n:09}")
+
+    identifiers = factory.LazyAttribute(lambda n: fake.substanceidentifierjson())
 
     class Meta:
         model = Substance

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,7 +5,6 @@ from faker.providers import BaseProvider
 from resolver.models import User, Substance
 
 fake = Faker()
-Faker.seed(0)
 
 
 class UserFactory(factory.Factory):

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -374,7 +374,7 @@ def test_substance_index_delete(client, db, substance_factory):
 
 def test_resolve_many_substances(client, db, substance_factory):
     # add a lot of substances
-    substances = substance_factory.create_batch(100)
+    substances = substance_factory.create_batch(1000)
     db.session.add_all(substances)
     db.session.commit()
 

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -387,7 +387,6 @@ def test_resolve_many_substances(client, db, substance_factory):
     substance_later = substances[50]
 
     id_first = substance_first.id
-    id_later = substance_later.id
 
     # the index properties can be used here to fetch the preferred_name
     # without using the identifiers["preferred_name"] key
@@ -397,13 +396,6 @@ def test_resolve_many_substances(client, db, substance_factory):
     synonym_1_identifier_later = substance_later.identifiers["synonyms"][0][
         "identifier"
     ]
-    synonym_1_weight_later = substance_later.identifiers["synonyms"][0]["weight"]
-    synonym_1_type_later = substance_later.identifiers["synonyms"][0]["synonymtype"]
-
-    synonym_3_identifier_later = substance_later.identifiers["synonyms"][2][
-        "identifier"
-    ]
-    synonym_3_weight_later = substance_later.identifiers["synonyms"][2]["weight"]
 
     # make sure the factory generated distinct values
     assert (

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -372,7 +372,6 @@ def test_substance_index_delete(client, db, substance_factory):
     assert Substance.query.count() == 0
 
 
-
 def test_resolve_many_substances(client, db, substance_factory):
     # add a lot of substances
     substances = substance_factory.create_batch(1000)

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -1,4 +1,5 @@
 import pytest
+import copy
 from flask import url_for
 
 from resolver.api.schemas import SubstanceSchema
@@ -179,6 +180,7 @@ def test_resolve_substance(client, db, substance):
         "display_name": "Kraft Miracle Whip Original Dressing",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
+        "compound_id": "DTXCID302000093",
         "synonyms": [
             {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
             {
@@ -246,8 +248,11 @@ def test_resolve_substance(client, db, substance):
     assert results["data"] == []
 
     # test preferred name match
-    preferred_name = "Miracle Whip"
-    search_url = url_for("resolved_substance_list", identifier=preferred_name)
+    # (encode spaces in string first?)
+    search_url = url_for(
+        "resolved_substance_list",
+        identifier="Miracle Whip",
+    )
     rep = client.get(search_url)
     assert rep.status_code == 200
     results = rep.get_json()
@@ -365,3 +370,97 @@ def test_substance_index_delete(client, db, substance_factory):
     assert resp.status_code == 200
     assert "Substance Index successfully cleared" in results["meta"]["message"]
     assert Substance.query.count() == 0
+
+
+def test_resolve_many_substances(client, db, substance_factory):
+    # add a lot of substances
+    substances = substance_factory.create_batch(100)
+    db.session.add_all(substances)
+    db.session.commit()
+
+    # query the database and
+    # pick some attributes to search for:
+
+    substances = Substance.query.all()
+
+    substance_first = substances[0]
+    substance_later = substances[50]
+
+    id_first = substance_first.id
+    id_later = substance_later.id
+
+    # the index properties can be used here to fetch the preferred_name
+    # without using the identifiers["preferred_name"] key
+    name_first = substance_first.preferred_name
+    name_later = substance_later.preferred_name
+
+    synonym_1_identifier_later = substance_later.identifiers["synonyms"][0][
+        "identifier"
+    ]
+    synonym_1_weight_later = substance_later.identifiers["synonyms"][0]["weight"]
+    synonym_1_type_later = substance_later.identifiers["synonyms"][0]["synonymtype"]
+
+    synonym_3_identifier_later = substance_later.identifiers["synonyms"][2][
+        "identifier"
+    ]
+    synonym_3_weight_later = substance_later.identifiers["synonyms"][2]["weight"]
+
+    # make sure the factory generated distinct values
+    assert (
+        substance_later.identifiers["preferred_name"]
+        != substance_first.identifiers["preferred_name"]
+    )
+
+    # Searching by ID should return one result
+    search_url = url_for("resolved_substance_list", identifier=id_first)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
+    # Searching by preferred_name should return one result
+    search_url = url_for("resolved_substance_list", identifier=name_first)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
+    # Searching by synonym should return one result when the Alternate CAS-RN
+    # synonyms are all unique
+    search_url = url_for(
+        "resolved_substance_list", identifier=synonym_1_identifier_later
+    )
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
+    # The Generic Name synonyms (index [2]) are not necessarily as unique,
+    # so create a condition where the search term is known to be a synonym and
+    # a preferred_name, and confirm that multiple records are returned
+    substance_first.identifiers = copy.deepcopy(substance_first.identifiers)
+    substance_first.identifiers["synonyms"][2]["identifier"] = name_later
+    db.session.add(substance_first)
+    db.session.commit()
+    assert substance_first.identifiers["synonyms"][2]["identifier"] == name_later
+
+    search_url = url_for("resolved_substance_list", identifier=name_later)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"]["count"] > 1
+
+    # A later substance's preferred_name has been assigned
+    # as a synonym to the first substance, so the first result
+    # should be the higher-scoring substance, which would normally
+    # not appear sorted at the beginning
+    assert results["data"][0]["attributes"]["score"] == 1
+    assert results["data"][1]["attributes"]["score"] < 1
+    # the "matches" dict should report what synonym type produced the match
+    assert "Generic Name" in results["data"][1]["attributes"]["matches"].keys()
+    # However many results there are, scores should descend monotonically
+    score_previous = 1.0
+    for d in results["data"]:
+        score_current = d["attributes"]["score"]
+        assert score_current <= score_previous
+        score_previous = score_current

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -45,13 +45,27 @@ def test_patch_substance(client, db, substance):
         "preferred_name": "Moperone Updated",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
+            {
+                "identifier": "0001050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": "1050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": "Meperon",
+                "weight": 0.75,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
         ],
     }
     data["data"]["id"] = substance.id
@@ -101,13 +115,23 @@ def test_create_substance(client, db):
         "display_name": "Miracle Whip",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "0001050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": "1050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -155,13 +179,23 @@ def test_resolve_substance(client, db, substance):
         "display_name": "Kraft Miracle Whip Original Dressing",
         "casrn": "1050-79-9",
         "inchikey": "AGAHNABIDCTLHW-UHFFFAOYSA-N",
-        "casalts": [
-            {"casalt": "0001050799", "weight": 0.5},
-            {"casalt": "1050799", "weight": 0.5},
-        ],
         "synonyms": [
-            {"identifier": "Meperon", "weight": 0.75},
-            {"identifier": "Methylperidol", "weight": 0.5},
+            {"identifier": "Meperon", "weight": 0.75, "synonymtype": "Generic Name"},
+            {
+                "identifier": "Methylperidol",
+                "weight": 0.5,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "0001050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
+            {
+                "identifier": "1050799",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
+            },
         ],
     }
     data["data"]["attributes"]["identifiers"] = idents
@@ -180,17 +214,21 @@ def test_resolve_substance(client, db, substance):
         "casrn": "3757-31-1",
         "inchikey": "UUTBLVFYDQGDNV-UHFFFAOYSA-N",
         "compound_id": "DTXCID302000003",
-        "casalts": [
-            {"casalt": "3757-31-1", "weight": 0.5},
-        ],
         "synonyms": [
             {
                 "identifier": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
                 "weight": 0.75,
+                "synonymtype": "Generic Name",
+            },
+            {
+                "identifier": "3757311",
+                "weight": 0.5,
+                "synonymtype": "Alternate CAS-RN",
             },
             {
                 "identifier": "N'-Butanoyl-5-nitrofuran-2-carbohydrazonamide",
                 "weight": 0.5,
+                "synonymtype": "Generic Name",
             },
         ],
     }
@@ -231,7 +269,14 @@ def test_resolve_substance(client, db, substance):
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
 
-    # test display name match
+    # test synonym matches
+    synonym = "3757311"
+    search_url = url_for("resolved_substance_list", identifier=synonym)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+
     synonym = "Meperon"
     search_url = url_for("resolved_substance_list", identifier=synonym)
     rep = client.get(search_url)
@@ -320,4 +365,3 @@ def test_substance_index_delete(client, db, substance_factory):
     assert resp.status_code == 200
     assert "Substance Index successfully cleared" in results["meta"]["message"]
     assert Substance.query.count() == 0
-


### PR DESCRIPTION
Closes: https://github.com/Chemical-Curation/chemcurator_django/issues/144

Requirements not mentioned in ticket:
- [ ]  `next` and `previous` links should include the search term - the `view_kwargs` metadata should carry this?
- [ ] Exact matching is case sensitive at the moment - should this be the case?

Note that this branch depends on #284's branch being merged in:
https://github.com/Chemical-Curation/resolver/pull/15

The search results are first selected with a 👍 or 👎  filter , then the result set is scored in the `ResourceManager`. 

The scores are reported in JSON `data["attributes]` and the matching attributes are provided as a separate list of `matches`, like so:
```YAML
{
  "data": [
    {
      "type": "substance_search_results",
      "attributes": {
        "matches": {
          "preferred_name": 1,
          "display_name": 1
        },
        "identifiers": {
          "casrn": "7722-84-1",
          "synonyms": [],
          "compound_id": "DTXCID502000024",
          "display_name": "Hydrogen Peroxide",
          "preferred_name": "Hydrogen Peroxide"
        },
        "score": 1
      },
      "id": "DTXSID202000002"
    }
  ]
}
```