### PR TITLE
9 port variables

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,3 @@
-# This is a simple Dockerfile to use while developing
-# It's not suitable for production
-#
-# It allows you to run both flask and celery if you enabled it
-# for flask: docker run --env-file=.flaskenv image flask run
-# for celery: docker run --env-file=.flaskenv image celery worker -A myapi.celery_app:app
-#
-# note that celery will require a running broker and result backend
 FROM python:3.8
 
 RUN mkdir /code
@@ -16,6 +8,7 @@ RUN pip install -r requirements.txt
 RUN pip install -e .
 
 COPY resolver resolver/
-COPY migrations migrations/
 
 EXPOSE 5000
+
+ENTRYPOINT ["resolver/docker-entrypoint.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-# WARNING: this file is not suitable for production, please use with caution
 version: "3"
 
 services:
@@ -6,36 +5,27 @@ services:
     image: postgres:12-alpine
     volumes:
       - postgres_data:/var/lib/postgresql/data/
-    env_file:
-      - ./.flaskenv
+    environment:
+        POSTGRES_USER: ${POSTGRES_USER}
+        POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+        POSTGRES_DB: ${POSTGRES_DB}
     ports:
-      - 5431:5432
-
-#  pgbouncer:
-#    image: pgbouncer/pgbouncer:1.12.0
-#    restart: unless-stopped
-#    env_file:
-#      - ./.flaskenv
-#    environment:
-#      DATABASES_HOST: ${SQL_HOST}
-#      DATABASES_PASSWORD: ${SQL_PASSWORD}
-#      DATABASES_PORT: ${SQL_PORT}
-#      DATABASES_USER: ${SQL_USER}
-#      PGBOUNCER_LISTEN_PORT: 5432
+      - "${POSTGRES_DB_PORT}:5432"
 
   web:
     image: resolver
     build: .
-    command: gunicorn -b 0.0.0.0:5000 resolver.wsgi:app
-    env_file:
-      - ./.flaskenv
+    depends_on:
+      - db
     environment:
-      - DATABASE_URI=postgresql://postgres:postgres@db:5432/resolver
+      - DATABASE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB}
+      - SECRET_KEY=${SECRET_KEY}
     volumes:
       - ./resolver:/code/resolver
-      - ./db/:/db/
+      - ./migrations:/code/migrations
     ports:
-      - "5000:5000"
+        - "${RESOLVER_PORT}:5000"
+    restart: always
 
 volumes:
   postgres_data:

--- a/resolver/app.py
+++ b/resolver/app.py
@@ -9,9 +9,6 @@ def create_app(testing=False, cli=False):
     """Application factory, used to create application"""
     app = Flask("resolver")
     app.config.from_object("resolver.config")
-    # this is the only place I was able to reliably set this variable
-    # and avoid getting nagged about it
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
 
     if testing is True:
         app.config["TESTING"] = True

--- a/resolver/docker-entrypoint.sh
+++ b/resolver/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+resolver db upgrade
+gunicorn -c resolver/gunicorn.py resolver.wsgi:app

--- a/resolver/gunicorn.py
+++ b/resolver/gunicorn.py
@@ -1,2 +1,2 @@
 bind = ":5000"
-workers=2
+workers = 2

--- a/resolver/gunicorn.py
+++ b/resolver/gunicorn.py
@@ -1,0 +1,2 @@
+bind = ":5000"
+workers=2

--- a/template.env
+++ b/template.env
@@ -1,19 +1,12 @@
-FLASK_APP=resolver.app:create_app
-FLASK_ENV=development
-
+SECRET_KEY=changeme
 # The POSTGRES_* variables are required by the docker-compose file
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=postgres
 POSTGRES_DB=resolver
 
-# The postgres bouncer is using these variables to connect:
-SQL_HOST=127.0.0.1
-SQL_PASSWORD=postgres
-SQL_PORT=5431
-SQL_USER=postgres
-# The redundancy should be tidied up
+# db port should only need to be changed for development if you have other containers running at 5432
+POSTGRES_DB_PORT=5432
+DATABASE_URI=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@127.0.0.1:${POSTGRES_DB_PORT}/${POSTGRES_DB}
 
-# The server is using 5431 to avoid conflicts with other apps
-DATABASE_URI=postgresql://postgres:postgres@127.0.0.1:5431/resolver
-
-
+# specify the port to run flask,used only in compose w/ gunicorn
+RESOLVER_PORT=5000

--- a/template.flaskenv
+++ b/template.flaskenv
@@ -1,19 +1,5 @@
-FLASK_ENV=development
+# these settings are used in development when using `$ resolver run`
 FLASK_APP=resolver.app:create_app
-SECRET_KEY=changeme
+FLASK_ENV=development
+FLASK_RUN_PORT=5000
 
-# The POSTGRES_* variables are required by the docker-compose file
-POSTGRES_USER=postgres
-POSTGRES_PASSWORD=postgres
-POSTGRES_DB=resolver
-
-# The postgres bouncer is using these variables to connect:
-SQL_HOST=127.0.0.1
-SQL_PASSWORD=postgres
-SQL_PORT=5431
-SQL_USER=postgres
-# The redundancy should be tidied up
-
-# The server is using 5431 to avoid conflicts with other apps
-DATABASE_URI=postgresql://postgres:postgres@127.0.0.1:5431/resolver
-SQLALCHEMY_TRACK_MODIFICATIONS=False

--- a/template.testenv
+++ b/template.testenv
@@ -1,2 +1,0 @@
-SECRET_KEY=testing
-DATABASE_URI=postgresql://postgres:postgres@127.0.0.1:5431/test_resolver

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import json
 import pytest
 from dotenv import load_dotenv
@@ -15,7 +16,8 @@ register(SubstanceFactory)
 
 @pytest.fixture(scope="session")
 def app():
-    load_dotenv(".testenv")
+    load_dotenv(".env")
+    os.environ["DATABASE_URI"] += "_test"
     app = create_app(testing=True)
     return app
 

--- a/tox.ini
+++ b/tox.ini
@@ -19,11 +19,7 @@ deps=
 ;  factory_boy
 ;  black
   -r requirements.txt
-setenv =
-       DATABASE_URI = postgresql://postgres:postgres@127.0.0.1:5431/resolver_test:
-       SECRET_KEY = testing
-       FLASK_ENV = development
-
+passenv=*
 commands=
   flake8 resolver
   black resolver --check


### PR DESCRIPTION
closes #9 

there are a couple of files created here, `gunicorn.py` will be used for config when running gunicorn in the Dockerfile. An entrypoint was added to `resolver upgrade` the DB when the container is run.

env vars needed for production are all in the `.env` file, for development the `.flask` env can be used to use `resolver run` command.

I've removed the `.testenv` and passed in the env vars to tox with the `.env`

Be sure to rewrite your `.env` and `.flaskenv` files when chcking this out! the `.testenv` can be deleted in your local repo.

You can specify ports for either container `web` or `db` so you can run PG at whatever port you need.