### PR TITLE
21 remove resolver containment searches

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -280,20 +280,20 @@ class SubstanceSearchResultList(ResourceList):
                     Substance,
                     func.jsonb_array_elements(Substance.identifiers["synonyms"]),
                 )
-                .filter(val["identifier"].astext.ilike(f"%{search_term}%"))
+                .filter(val["identifier"].astext.ilike(f"{search_term}"))
                 .subquery()
             )
 
             query_ = self.session.query(Substance,).filter(
                 or_(
                     Substance.identifiers["preferred_name"].astext.ilike(
-                        f"%{search_term}%"
+                        f"{search_term}"
                     ),
                     Substance.identifiers["compound_id"].astext.ilike(search_term),
                     Substance.id.ilike(search_term),
-                    Substance.identifiers["casrn"].astext.ilike(f"%{search_term}%"),
+                    Substance.identifiers["casrn"].astext.ilike(f"{search_term}"),
                     Substance.identifiers["display_name"].astext.ilike(
-                        f"%{search_term}%"
+                        f"{search_term}"
                     ),
                     Substance.id.in_(synonym_subquery),
                 )

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -305,29 +305,29 @@ def test_resolve_substance(client, db, substance):
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
 
-    # test name containment
+    # test name containment (Partial Matching Removed in ticket #21)
     partial_name = "Miracle"
     search_url = url_for("resolved_substance_list", identifier=partial_name)
     rep = client.get(search_url)
     assert rep.status_code == 200
     results = rep.get_json()
-    assert results["meta"] == {"count": 1}
+    assert results["meta"] == {"count": 0}
 
     # test case insensitivity
-    partial_name = "miracle"
+    partial_name = "miracle whip"
     search_url = url_for("resolved_substance_list", identifier=partial_name)
     rep = client.get(search_url)
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
 
-    # test multiple matches
+    # test multiple matches (Partial Matching Removed in ticket #21)
     partial_name = "Original Dressing"
     search_url = url_for("resolved_substance_list", identifier=partial_name)
     rep = client.get(search_url)
     assert rep.status_code == 200
     results = rep.get_json()
-    assert results["meta"] == {"count": 2}
+    assert results["meta"] == {"count": 0}
 
 
 # Tests both create and update functionality using param create_test.
@@ -479,7 +479,8 @@ def test_resolve_searches_all_rows(client, db, substance_factory):
 
     assert rep.status_code == 200
     results = rep.get_json()
-    assert results["meta"] == {"count": 101}  # 100 close matches + 1 exact match
+    # 100 close matches + 1 exact match (Ticket #21 containment no longer matches. Count from 101 to 1)
+    assert results["meta"] == {"count": 1}
 
     first_result = results["data"][0]
     assert first_result["attributes"]["score"] == 1  # First result is a perfect score


### PR DESCRIPTION
closes #21 

Pretty straight forward.  Case insensitive matching is not in place but exact matches are now required for Display Name, Preferred Name, CAS-RN, and Synonym Identifier.  All 4 of these are still case-insensitive.

 SID and CID remain unchanged as they were always case-insensitive, exact matches.

Case-insensitive exact matches are not scored.   #22 will change this.

### To test with seed data
_Hydrogen_ - returns nothing
_hydrogen peroxide_ - returns 1 row with a score of 0 for insensitivity.  #22 will change this.
_Hydrogen Peroxide_ - returns 1 row with a score of 1 for matching on Display Name and Preferred Name