### PR TITLE
22 case insensitive scoring

### DIFF
--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -38,7 +38,7 @@ class Substance(db.Model):
                 # an exact match against a top-level identifier
                 # yields a 1.0 score
                 if self.identifiers[id_name]:
-                    if self.identifiers[id_name] == searchterm:
+                    if self.identifiers[id_name].casefold() == searchterm.casefold():
                         matchlist[id_name] = 1
             if self.identifiers["synonyms"]:
                 synonyms = self.identifiers["synonyms"]
@@ -47,7 +47,7 @@ class Substance(db.Model):
                 # set to
                 for synonym in synonyms:
                     synid = synonym["identifier"] if synonym["identifier"] else ""
-                    if synid == searchterm:
+                    if synid.casefold() == searchterm.casefold():
                         matchlist[synonym["synonymtype"]] = synonym["weight"]
             if bool(matchlist):
                 return matchlist

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -320,6 +320,7 @@ def test_resolve_substance(client, db, substance):
     assert rep.status_code == 200
     results = rep.get_json()
     assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["score"] == 1  # exact match despite case
 
     # test multiple matches (Partial Matching Removed in ticket #21)
     partial_name = "Original Dressing"


### PR DESCRIPTION
closes #22 

Adds case-insensitivity to the results scoring.  I've opted to use `.casefold()` rather than `.lower()` due to it seemingly having better functionality with unicode.

### To test with seed data
`{{BaseURL}}/resolver?identifier=`

Hydrogen - returns nothing
hydrogen peroxide - returns 1 row with a score of 1 for case-insensitive match on Display Name and Preferred Name.
Hydrogen Peroxide - returns 1 row with a score of 1 for a case-sensitive match on Display Name and Preferred Name.