### PR TITLE
11 resolve smiles inchi

### DIFF
--- a/resolver/api/data_layers.py
+++ b/resolver/api/data_layers.py
@@ -1,6 +1,8 @@
 from flask import current_app, request
 from flask_rest_jsonapi.data_layers.alchemy import SqlalchemyDataLayer
 
+from resolver.extensions import getInchikey
+
 
 class SearchDataLayer(SqlalchemyDataLayer):
     """Sqlalchemy data layer specifically to use python sorting."""
@@ -72,7 +74,8 @@ class SearchDataLayer(SqlalchemyDataLayer):
         to the query. The score_result method only works at the row/instance level
         """
         if request.args.get("identifier") is not None:
-            search_term = request.args.get("identifier")
+            search_term = getInchikey(request.args.get("identifier"))
+
             collection.sort(key=lambda x: x.score_result(search_term), reverse=True)
 
         return collection

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -1,11 +1,12 @@
 from flask import request
+from indigo import Indigo
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB
 
 from resolver.api.data_layers import SearchDataLayer
 from resolver.api.schemas import SubstanceSchema, SubstanceSearchResultSchema
 from resolver.models import Substance
-from resolver.extensions import db
+from resolver.extensions import db, getInchikey
 from sqlalchemy.sql.expression import or_  # , literal_column
 
 from flask_rest_jsonapi import ResourceDetail, ResourceList
@@ -269,7 +270,7 @@ class SubstanceSearchResultList(ResourceList):
     def query(self, view_kwargs):
         query_ = self.session.query(Substance)
         if request.args.get("identifier") is not None:
-            search_term = request.args.get("identifier")
+            search_term = getInchikey(request.args.get("identifier"))
 
             # This allows reference to the aliased results from synonym select_from jsonb_array_elements
             val = db.column("value", type_=JSONB)

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -1,5 +1,4 @@
 from flask import request
-from indigo import Indigo
 from sqlalchemy import func
 from sqlalchemy.dialects.postgresql import JSONB
 

--- a/resolver/api/schemas/substance.py
+++ b/resolver/api/schemas/substance.py
@@ -1,5 +1,5 @@
 from resolver.models import Substance
-from resolver.extensions import db
+from resolver.extensions import db, getInchikey
 from marshmallow_jsonapi.schema import Schema
 from marshmallow_jsonapi import fields
 from flask import request
@@ -23,10 +23,10 @@ class SubstanceSearchResultSchema(Schema):
     identifiers = fields.Raw(required=True)
     # the matches will be the fields in which the identifier was found
     matches = fields.Function(
-        lambda obj: obj.get_matches(request.args.get("identifier"))
+        lambda obj: obj.get_matches(getInchikey(request.args.get("identifier")))
     )
     score = fields.Function(
-        lambda obj: obj.score_result(request.args.get("identifier"))
+        lambda obj: obj.score_result(getInchikey(request.args.get("identifier")))
     )
 
     class Meta:

--- a/resolver/extensions.py
+++ b/resolver/extensions.py
@@ -4,7 +4,7 @@ All extensions here are used as singletons and
 initialized in application factory
 """
 from flask_sqlalchemy import SQLAlchemy
-from indigo import Indigo
+from indigo import Indigo, IndigoException
 from indigo.inchi import IndigoInchi
 from passlib.context import CryptContext
 from flask_jwt_extended import JWTManager
@@ -37,7 +37,7 @@ def getInchikey(mol: str) -> str:
         loaded_molecule = indigo.loadMolecule(mol)
         inchi = indigo_inchi.getInchi(loaded_molecule)
         return indigo_inchi.getInchiKey(inchi)
-    except:
+    except IndigoException:
         return mol
 
 

--- a/resolver/extensions.py
+++ b/resolver/extensions.py
@@ -4,6 +4,8 @@ All extensions here are used as singletons and
 initialized in application factory
 """
 from flask_sqlalchemy import SQLAlchemy
+from indigo import Indigo
+from indigo.inchi import IndigoInchi
 from passlib.context import CryptContext
 from flask_jwt_extended import JWTManager
 from flask_marshmallow import Marshmallow
@@ -18,6 +20,25 @@ ma = Marshmallow()
 migrate = Migrate()
 apispec = APISpecExt()
 pwd_context = CryptContext(schemes=["pbkdf2_sha256"], deprecated="auto")
+
+# Indigo packages
+indigo = Indigo()
+indigo_inchi = IndigoInchi(indigo)
+
+
+def getInchikey(mol: str) -> str:
+    """Attempts to convert a string into an inchikey.
+
+    IndigoInchi requires an Indigo molecule to be loaded.
+    First load the molecule into indigo then recieve the inchi
+    string from IndigoInchi.  Hash that string into the inchikey.
+    """
+    try:
+        loaded_molecule = indigo.loadMolecule(mol)
+        inchi = indigo_inchi.getInchi(loaded_molecule)
+        return indigo_inchi.getInchiKey(inchi)
+    except:
+        return mol
 
 
 def init_db():

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
         "flask-jwt-extended",
         "flask-marshmallow",
         "gunicorn",
+        "epam.indigo",
         "marshmallow-sqlalchemy",
         "python-dotenv",
         "psycopg2-binary",

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -214,7 +214,7 @@ def test_resolve_substance(client, db, substance):
         "preferred_name": "Butyric acid, 2-(5-nitro-alpha-iminofurfuryl)hydrazide",
         "display_name": "Butyric acid Original Dressing",
         "casrn": "3757-31-1",
-        "inchikey": "UUTBLVFYDQGDNV-UHFFFAOYSA-N",
+        "inchikey": "AECPIECQUWDXGM-UXBLZVDNSA-N",  # this inchikey is verified vs SMILES and inchi searches.
         "compound_id": "DTXCID302000003",
         "synonyms": [
             {
@@ -306,7 +306,25 @@ def test_resolve_substance(client, db, substance):
     assert results["meta"] == {"count": 1}
 
     # test Inchikey match
-    inchikey = "UUTBLVFYDQGDNV-UHFFFAOYSA-N"
+    inchikey = "AECPIECQUWDXGM-UXBLZVDNSA-N"
+    search_url = url_for("resolved_substance_list", identifier=inchikey)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["score"] == 1
+
+    # test SMILES match
+    smiles = "CCCC(=O)N/N=C(/C1=CC=C(O1)[N+](=O)[O-])"
+    search_url = url_for("resolved_substance_list", identifier=smiles)
+    rep = client.get(search_url)
+    assert rep.status_code == 200
+    results = rep.get_json()
+    assert results["meta"] == {"count": 1}
+    assert results["data"][0]["attributes"]["score"] == 1
+
+    # test Inchi match
+    inchikey = "InChI=1S/C9H11N3O4/c1-2-3-8(13)11-10-6-7-4-5-9(16-7)12(14)15/h4-6H,2-3H2,1H3,(H,11,13)/b10-6+"
     search_url = url_for("resolved_substance_list", identifier=inchikey)
     rep = client.get(search_url)
     assert rep.status_code == 200


### PR DESCRIPTION
closes #11 

~~Needs rebase / merge onto dev when #27 is merged.~~ Done.

This simple approach to first attempt to convert any search term into an inchikey then match against that.  This is probably not the preferred way to do this.  This matches the below ask on the ticket.

>The resolver must be able to take in a smiles or inchi, convert it to inchikey and return the correct chemical based on inchikey lookup

**Notes:**  An alternative way of approaching the problem would be to index the InChI and SMILES on addition of a new document.  This would speed up the search time, something that should be more common and where through-put matters, at the cost of index time where speedy responses are less important.

Either way the difference is in milliseconds and perhaps some code clarity.  This would also require the substance document to contain something that could be loaded as a molecule in indigo, which may not be desired.