### PR TITLE
23 resolution pagination

### DIFF
--- a/resolver/api/data_layers.py
+++ b/resolver/api/data_layers.py
@@ -36,7 +36,7 @@ class SearchDataLayer(SqlalchemyDataLayer):
 
         collection = self.calculate_scores(collection, qs, view_kwargs)
 
-        collection = self.paginate_collection(collection, qs.pagination)
+        # collection = self.paginate_collection(collection, qs.pagination)
 
         collection = self.after_get_collection(collection, qs, view_kwargs)
 

--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -301,6 +301,11 @@ class SubstanceSearchResultList(ResourceList):
             )
         return query_
 
+    def after_get(self, result):
+        # Remove Pagination
+        result.pop("links", None)
+        return result
+
     methods = ["GET"]
     schema = SubstanceSearchResultSchema
     # get_schema_kwargs = {"identifier": ("identifier",)}

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -496,17 +496,20 @@ def test_resolve_searches_all_rows(client, db, substance_factory):
     assert first_result["attributes"]["score"] == 1  # First result is a perfect score
     assert first_result["id"] == exact_substance.id  # First result is the correct sid
 
+
 def test_resolve_no_pagination(client, db, substance_factory):
     n = 100
+    identifier = "Substance"
 
     # Make n substances
     for i in range(n):
         substance = substance_factory()
+        substance.identifiers["preferred_name"] = f"{identifier}"
         db.session.add(substance)
         db.session.commit()
 
-    #search the 100
-    search_url = url_for("resolved_substance_list")
+    # search all substances
+    search_url = url_for("resolved_substance_list", identifier=identifier)
     resp = client.get(search_url)
     results = resp.get_json()
 

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -495,3 +495,20 @@ def test_resolve_searches_all_rows(client, db, substance_factory):
     first_result = results["data"][0]
     assert first_result["attributes"]["score"] == 1  # First result is a perfect score
     assert first_result["id"] == exact_substance.id  # First result is the correct sid
+
+def test_resolve_no_pagination(client, db, substance_factory):
+    n = 100
+
+    # Make n substances
+    for i in range(n):
+        substance = substance_factory()
+        db.session.add(substance)
+        db.session.commit()
+
+    #search the 100
+    search_url = url_for("resolved_substance_list")
+    resp = client.get(search_url)
+    results = resp.get_json()
+
+    assert not results.get("links")
+    assert len(results["data"]) == n


### PR DESCRIPTION
closes #23 

Commented out the pagination from the collection and popped the "links" section of the results.

The test is taking advantage of the fact that we don't need an identifier to search.  This is almost definitely an issue as an empty identifier search could possibly crash resolver. 