### PR TITLE
GH#32 require identifier parameter at /api/v1/resolver

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -9,6 +9,7 @@ from resolver.extensions import db, getInchikey
 from sqlalchemy.sql.expression import or_  # , literal_column
 
 from flask_rest_jsonapi import ResourceDetail, ResourceList
+from flask_rest_jsonapi.exceptions import BadRequest
 
 
 class SubstanceResource(ResourceDetail):
@@ -268,7 +269,9 @@ class SubstanceSearchResultList(ResourceList):
 
     def query(self, view_kwargs):
         query_ = self.session.query(Substance)
-        if request.args.get("identifier") is not None:
+        if not request.args.get("identifier"):
+            raise BadRequest("'identifier' is a required parameter for this endpoint.")
+        else:
             search_term = getInchikey(request.args.get("identifier"))
 
             # This allows reference to the aliased results from synonym select_from jsonb_array_elements

--- a/resolver/manage.py
+++ b/resolver/manage.py
@@ -1,3 +1,5 @@
+import os
+import subprocess
 import click
 from flask.cli import FlaskGroup
 
@@ -18,6 +20,14 @@ def cli():
 def initdb():
     init_db()
     print("Database Created")
+
+
+@cli.command("lint")
+def lint():
+    """lint all of the files in this repo with flake8 and black"""
+    if "resolver" in os.getcwd():
+        subprocess.run(["black", "."], cwd=os.getcwd())
+        subprocess.run(["flake8"], cwd=os.getcwd())
 
 
 @cli.command("init")

--- a/resolver/manage.py
+++ b/resolver/manage.py
@@ -3,6 +3,7 @@ import subprocess
 import click
 from flask.cli import FlaskGroup
 
+from flask import current_app
 from resolver.app import create_app
 from resolver.extensions import init_db
 
@@ -25,9 +26,9 @@ def initdb():
 @cli.command("lint")
 def lint():
     """lint all of the files in this repo with flake8 and black"""
-    if "resolver" in os.getcwd():
-        subprocess.run(["black", "."], cwd=os.getcwd())
-        subprocess.run(["flake8"], cwd=os.getcwd())
+    resolver_dir = os.path.dirname(current_app.root_path)
+    subprocess.run(["black", "."], cwd=resolver_dir)
+    subprocess.run(["flake8"], cwd=resolver_dir)
 
 
 @cli.command("init")

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -533,3 +533,22 @@ def test_resolve_no_pagination(client, db, substance_factory):
 
     assert not results.get("links")
     assert len(results["data"]) == n
+
+
+def test_resolve_identifier_required_parameter(client, db, substance_factory):
+
+    # no identifier filter parameter
+    search_url = url_for("resolved_substance_list")
+    rep = client.get(search_url)
+
+    assert rep.status_code == 400
+    resp = rep.get_json()
+    assert resp["errors"][0]["detail"] == "'identifier' is a required parameter for this endpoint."
+
+    # empty string in identifier parameter
+    search_url = url_for("resolved_substance_list", identifier="")
+    rep = client.get(search_url)
+
+    assert rep.status_code == 400
+    resp = rep.get_json()
+    assert resp["errors"][0]["detail"] == "'identifier' is a required parameter for this endpoint."

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -543,7 +543,10 @@ def test_resolve_identifier_required_parameter(client, db, substance_factory):
 
     assert rep.status_code == 400
     resp = rep.get_json()
-    assert resp["errors"][0]["detail"] == "'identifier' is a required parameter for this endpoint."
+    assert (
+        resp["errors"][0]["detail"]
+        == "'identifier' is a required parameter for this endpoint."
+    )
 
     # empty string in identifier parameter
     search_url = url_for("resolved_substance_list", identifier="")
@@ -551,4 +554,7 @@ def test_resolve_identifier_required_parameter(client, db, substance_factory):
 
     assert rep.status_code == 400
     resp = rep.get_json()
-    assert resp["errors"][0]["detail"] == "'identifier' is a required parameter for this endpoint."
+    assert (
+        resp["errors"][0]["detail"]
+        == "'identifier' is a required parameter for this endpoint."
+    )


### PR DESCRIPTION
this will raise a `BadRequest` error if either there is no `identifer` param or if it is just an empty string, 
`http://127.0.0.1:4242/api/v1/resolver?identifier=`
`http://127.0.0.1:4242/api/v1/resolver`

these will both return
```
{
  "errors": [
    {
      "detail": "'identifier' is a required parameter for this endpoint.",
      "status": "400",
      "title": "Bad request"
    }
  ],
  "jsonapi": {
    "version": "1.0"
  }
}
```