### PR TITLE
156 query casrn corrections

### DIFF
--- a/resolver/api/resources/substance.py
+++ b/resolver/api/resources/substance.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import JSONB
 
 from resolver.api.data_layers import SearchDataLayer
 from resolver.api.schemas import SubstanceSchema, SubstanceSearchResultSchema
+from resolver.commons.search_helpers import prep_casrn
 from resolver.models import Substance
 from resolver.extensions import db, getInchikey
 from sqlalchemy.sql.expression import or_  # , literal_column
@@ -292,7 +293,9 @@ class SubstanceSearchResultList(ResourceList):
                     Substance.identifiers["inchikey"].astext.ilike(f"{search_term}"),
                     Substance.identifiers["compound_id"].astext.ilike(search_term),
                     Substance.id.ilike(search_term),
-                    Substance.identifiers["casrn"].astext.ilike(f"{search_term}"),
+                    Substance.identifiers["casrn"].astext.ilike(
+                        prep_casrn(search_term)
+                    ),
                     Substance.identifiers["display_name"].astext.ilike(
                         f"{search_term}"
                     ),

--- a/resolver/commons/search_helpers.py
+++ b/resolver/commons/search_helpers.py
@@ -1,0 +1,5 @@
+def prep_casrn(term: str) -> str:
+    term = term.replace("-", "").lstrip("0")
+    if len(term) > 4:
+        term = term[:-3] + "-" + term[-3:-1] + "-" + term[-1]
+    return term

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -1,3 +1,4 @@
+from resolver.commons.search_helpers import prep_casrn
 from resolver.extensions import db
 
 from sqlalchemy.dialects.postgresql import JSONB
@@ -55,6 +56,10 @@ class Substance(db.Model):
                     synid = synonym["identifier"] if synonym["identifier"] else ""
                     if synid.casefold() == searchterm.casefold():
                         matchlist[synonym["synonymtype"]] = synonym["weight"]
+            if matchlist.get("casrn") is None and self.identifiers.get(
+                "casrn"
+            ) == prep_casrn(searchterm):
+                matchlist["casrn"] = 0.25
             if bool(matchlist):
                 return matchlist
             else:

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -59,7 +59,7 @@ class Substance(db.Model):
             if matchlist.get("casrn") is None and self.identifiers.get(
                 "casrn"
             ) == prep_casrn(searchterm):
-                matchlist["casrn"] = 0.25
+                matchlist["casrn"] = 0.75  # primary match of 1 - .25 penalty for mistype
             if bool(matchlist):
                 return matchlist
             else:

--- a/resolver/models/substance.py
+++ b/resolver/models/substance.py
@@ -59,7 +59,9 @@ class Substance(db.Model):
             if matchlist.get("casrn") is None and self.identifiers.get(
                 "casrn"
             ) == prep_casrn(searchterm):
-                matchlist["casrn"] = 0.75  # primary match of 1 - .25 penalty for mistype
+                matchlist[
+                    "casrn"
+                ] = 0.75  # primary match of 1 - .25 penalty for mistype
             if bool(matchlist):
                 return matchlist
             else:

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -340,8 +340,8 @@ def test_resolve_substance(client, db, substance):
         assert rep.status_code == 200
         results = rep.get_json()
         assert results["meta"] == {"count": 1}
-        assert results["data"][0]["attributes"]["score"] == .25
-        assert results["data"][0]["attributes"]["matches"]["casrn"] == .25
+        assert results["data"][0]["attributes"]["score"] == 0.25
+        assert results["data"][0]["attributes"]["matches"]["casrn"] == 0.25
 
     # test name containment (Partial Matching Removed in ticket #21)
     partial_name = "Miracle"

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -340,8 +340,8 @@ def test_resolve_substance(client, db, substance):
         assert rep.status_code == 200
         results = rep.get_json()
         assert results["meta"] == {"count": 1}
-        assert results["data"][0]["attributes"]["score"] == 0.25
-        assert results["data"][0]["attributes"]["matches"]["casrn"] == 0.25
+        assert results["data"][0]["attributes"]["score"] == 0.75
+        assert results["data"][0]["attributes"]["matches"]["casrn"] == 0.75
 
     # test name containment (Partial Matching Removed in ticket #21)
     partial_name = "Miracle"

--- a/tests/test_substances.py
+++ b/tests/test_substances.py
@@ -332,6 +332,17 @@ def test_resolve_substance(client, db, substance):
     assert results["meta"] == {"count": 1}
     assert results["data"][0]["attributes"]["score"] == 1
 
+    # test mis-formatted CASRN matches (1050799 and 0001050799 match as synonyms)
+    bad_casrns = ["001050799", "000001050-7-99"]
+    for bad_casrn in bad_casrns:
+        search_url = url_for("resolved_substance_list", identifier=bad_casrn)
+        rep = client.get(search_url)
+        assert rep.status_code == 200
+        results = rep.get_json()
+        assert results["meta"] == {"count": 1}
+        assert results["data"][0]["attributes"]["score"] == .25
+        assert results["data"][0]["attributes"]["matches"]["casrn"] == .25
+
     # test name containment (Partial Matching Removed in ticket #21)
     partial_name = "Miracle"
     search_url = url_for("resolved_substance_list", identifier=partial_name)


### PR DESCRIPTION
closes [django#156](https://github.com/chemical-curation/chemcurator_django/issues/156)

Adds a "helper" function that strips a CAS-RNs original dashes and left strips 0's then inserts dashes where necessary. (any number of chars - 2 chars - 1 char)

These "corrected" CAS-RNs are then searched in the DB in place of the search string.

When scoring the same conversion to "corrected" CAS-RN only when there is no straight match on CAS-RN.