### PR TITLE
Lock jwt version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         "flask-sqlalchemy",
         "flask-restful",
         "flask-migrate",
-        "flask-jwt-extended",
+        "flask-jwt-extended==3.24.1",
         "flask-marshmallow",
         "gunicorn",
         "epam.indigo",


### PR DESCRIPTION
Fixes the `docker-compose build` bug brought about by `flask-jwt-extended` being updated.  

We should probably lock all of our versions in a ticket.

### To replicate on dev:

1. docker-compose build --no-cache
2. docker-compose down
3. docker-compose up

### Expected (activity on branch `hotfix-jwt-version-lock`):

Resolver container should start and accept traffic. (http://127.0.0.1:5000/swagger-ui is a good url to test against)

### Actual:

Resolver restarts on loop due to `flask-jwt-extended` being updated